### PR TITLE
s-1638-make-hubspot-ids-available-to-exports

### DIFF
--- a/tap_hubspot/hubspot.py
+++ b/tap_hubspot/hubspot.py
@@ -48,6 +48,7 @@ LOGGER = singer.get_logger()
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 MANDATORY_PROPERTIES = {
     "companies": [
+        "hs_object_id",
         "name",
         "country",
         "domain",
@@ -109,6 +110,7 @@ MANDATORY_PROPERTIES = {
         "plan_mrr" # agencyanalytics_com
     ],
     "contacts": [
+        "hs_object_id",
         "email",
         "emailadresse",
         "hs_email_domain",


### PR DESCRIPTION
We can add the property 'hs_object_id' to the contact and company objects so it is available for customers in the custom properties configuration.