### PR TITLE
S 1675 tap hubspot sync all properties in

### DIFF
--- a/tap_hubspot/hubspot.py
+++ b/tap_hubspot/hubspot.py
@@ -84,8 +84,8 @@ MANDATORY_PROPERTIES = {
         "class",  # trengo custom field
         "recent_deal_amount",  # trengo
         "initial_deal_size",  # trengo
-        "became_a_sal", # trengo
-        "became_a_customer_date", # trengo
+        "became_a_sal",  # trengo
+        "became_a_customer_date",  # trengo
         "hs_additional_domains",
         "marketing_pipeline_value_in__",  # capmo
         "recent_conversion_date",  # capmo

--- a/tap_hubspot/hubspot.py
+++ b/tap_hubspot/hubspot.py
@@ -307,15 +307,12 @@ class Hubspot:
     ) -> Iterable[Tuple[Dict, datetime]]:
         filter_key = "hs_lastmodifieddate"
         obj_type = "deals"
+        primary_key = "hs_object_id"
 
         properties = self.get_object_properties(obj_type)
 
         gen = self.search(
-            obj_type,
-            filter_key,
-            start_date,
-            end_date,
-            properties,
+            obj_type, filter_key, start_date, end_date, properties, primary_key
         )
 
         for chunk in chunker(gen, 50):
@@ -595,15 +592,12 @@ class Hubspot:
     ) -> Iterable[Tuple[Dict, datetime]]:
         filter_key = "hs_lastmodifieddate"
         obj_type = "companies"
+        primary_key = "hs_object_id"
 
         properties = self.get_object_properties(obj_type)
 
         companies = self.search(
-            obj_type,
-            filter_key,
-            start_date,
-            end_date,
-            properties,
+            obj_type, filter_key, start_date, end_date, properties, primary_key
         )
 
         for company in companies:
@@ -704,13 +698,10 @@ class Hubspot:
         filter_key = "hs_lastmodifieddate"
         obj_type = "calls"
         properties = self.get_object_properties(obj_type)
+        primary_key = "hs_object_id"
 
         gen = self.search(
-            obj_type,
-            filter_key,
-            start_date,
-            end_date,
-            properties,
+            obj_type, filter_key, start_date, end_date, properties, primary_key
         )
         return self.attach_engagement_associations(
             obj_type=obj_type,
@@ -724,13 +715,9 @@ class Hubspot:
         filter_key = "hs_lastmodifieddate"
         obj_type = "meetings"
         properties = self.get_object_properties(obj_type)
-
+        primary_key = "hs_object_id"
         gen = self.search(
-            obj_type,
-            filter_key,
-            start_date,
-            end_date,
-            properties,
+            obj_type, filter_key, start_date, end_date, properties, primary_key
         )
 
         return self.attach_engagement_associations(
@@ -745,13 +732,10 @@ class Hubspot:
         filter_key = "hs_lastmodifieddate"
         obj_type = "emails"
         properties = self.get_object_properties(obj_type)
+        primary_key = "hs_object_id"
 
         gen = self.search(
-            obj_type,
-            filter_key,
-            start_date,
-            end_date,
-            properties,
+            obj_type, filter_key, start_date, end_date, properties, primary_key
         )
 
         return self.attach_engagement_associations(
@@ -766,13 +750,10 @@ class Hubspot:
         filter_key = "hs_lastmodifieddate"
         obj_type = "notes"
         properties = self.get_object_properties(obj_type)
+        primary_key = "hs_object_id"
 
         gen = self.search(
-            obj_type,
-            filter_key,
-            start_date,
-            end_date,
-            properties,
+            obj_type, filter_key, start_date, end_date, properties, primary_key
         )
 
         return self.attach_engagement_associations(
@@ -787,13 +768,9 @@ class Hubspot:
         filter_key = "hs_lastmodifieddate"
         obj_type = "tasks"
         properties = self.get_object_properties(obj_type)
-
+        primary_key = "hs_object_id"
         gen = self.search(
-            obj_type,
-            filter_key,
-            start_date,
-            end_date,
-            properties,
+            obj_type, filter_key, start_date, end_date, properties, primary_key
         )
 
         return self.attach_engagement_associations(


### PR DESCRIPTION
we had issue when using search api to [sync sendcloud_com contact table](https://dreamdataio.slack.com/archives/C01GT7JSM0F/p1653384463945499) before. 
The issue was that we get into an infinite loop. 
That is because sendcloud has a lot of contacts that has the same `lastmodifieddate`. And Hubspot has limit of max 10k result per query.
The third commit fix this issue by sorting records with primary key and never changing the start date.
After merging this, I will test on sendcloud again. If it fix the issue, I will migrate companies table too

<img width="1092" alt="Screenshot 2023-02-02 at 16 25 18" src="https://user-images.githubusercontent.com/48968138/216366767-fbc0eccf-4c4c-4925-a03b-2f449b31698d.png">
