### PR TITLE
resync all marketing events each run

### DIFF
--- a/tap_hubspot/stream.py
+++ b/tap_hubspot/stream.py
@@ -86,16 +86,11 @@ class Stream:
         start_date = parser.isoparse(current_bookmark)
         if self.tap_stream_id in [
             "contacts",
-            "marketing_events",
-            "marketing_event_participations",
         ]:
             # tracking data sync is dependent on contacts sync
             # hubspot does not return tracking data for contacts that are recently created
             # we need to always rewind 1 day to fetch the contacts
 
-            # marketing_events and marketing_event_participations are Hubspot's third-party integrations
-            # there might be delays for data to be available in Hubspot
-            # to avoid missing data, we need to always rewind 1 day to fetch the data
             start_date = start_date - timedelta(days=1)
         LOGGER.info(f"using 'start_date' from previous state: {start_date}")
         return start_date, end_date


### PR DESCRIPTION
Marketing Events endpoint is in Beta, it returns 500 randomly for some customers 
Because the state can not be trusted, so we resync all data in each run 
I also remove the retry on 500
I have submit a post in Hubspot Developer forum for this issue
https://community.hubspot.com/t5/APIs-Integrations/Marketing-Events-API-participants-breakdown-return-500/td-p/1092393


